### PR TITLE
RTL support for grid

### DIFF
--- a/internal/FixedDataTableCell.js
+++ b/internal/FixedDataTableCell.js
@@ -319,7 +319,7 @@ var FixedDataTableCell = (0, _createReactClass2.default)({
     );
   },
   _onColumnResizerMouseDown: function _onColumnResizerMouseDown( /*object*/event) {
-    this.props.onColumnResize(this.props.left, this.props.width, this.props.minWidth, this.props.maxWidth, this.props.columnKey, event);
+    this.props.onColumnResize(document.dir !== "rtl" ? this.props.left : this.props.columnGroupWidth - this.props.left, this.props.width, this.props.minWidth, this.props.maxWidth, this.props.columnKey, event);
   },
   _onColumnReorderMouseDown: function _onColumnReorderMouseDown( /*object*/event) {
     this.props.onColumnReorder(this.props.columnKey, this.props.width, this.props.left, event);

--- a/internal/FixedDataTableCell.js
+++ b/internal/FixedDataTableCell.js
@@ -160,16 +160,23 @@ var FixedDataTableCell = (0, _createReactClass2.default)({
     };
 
     if (props.isColumnReordering) {
-      var originalLeft = props.columnReorderingData.originalLeft;
-      var reorderCellLeft = originalLeft + props.columnReorderingData.dragDistance;
-      var farthestPossiblePoint = props.columnGroupWidth - props.columnReorderingData.columnWidth;
+      var originalLeft, reorderCellLeft, farthestPossiblePoint;
+      if (document.dir !== "rtl") {
+        originalLeft = props.columnReorderingData.originalLeft;
+        reorderCellLeft = originalLeft + props.columnReorderingData.dragDistance;
+        farthestPossiblePoint = props.columnGroupWidth - props.columnReorderingData.columnWidth;
+      } else {
+        originalLeft = props.columnReorderingData.originalLeft;
+        reorderCellLeft = originalLeft - props.columnReorderingData.dragDistance;
+        farthestPossiblePoint = props.columnGroupWidth - props.columnReorderingData.columnWidth;
+      }
 
       // ensure the cell isn't being dragged out of the column group
       reorderCellLeft = Math.max(reorderCellLeft, 0);
       reorderCellLeft = Math.min(reorderCellLeft, farthestPossiblePoint);
 
       if (props.columnKey === props.columnReorderingData.columnKey) {
-        newState.displacement = reorderCellLeft - props.left;
+        newState.displacement = originalLeft + props.columnReorderingData.dragDistance - props.left;
         newState.isReorderingThisColumn = true;
       } else {
         var reorderCellRight = reorderCellLeft + props.columnReorderingData.columnWidth;

--- a/internal/FixedDataTableCellGroup.js
+++ b/internal/FixedDataTableCellGroup.js
@@ -239,7 +239,7 @@ var FixedDataTableCellGroup = (0, _createReactClass2.default)({
   /*?number*/maxWidth,
   /*string|number*/columnKey,
   /*object*/event) {
-    this.props.onColumnResize && this.props.onColumnResize(this.props.offsetLeft, left - this.props.left + width, width, minWidth, maxWidth, columnKey, event);
+    this.props.onColumnResize && this.props.onColumnResize(this.props.offsetLeft, document.dir !== "rtl" ? left - this.props.left + width : left - this.props.left, width, minWidth, maxWidth, columnKey, event);
   }
 });
 

--- a/internal/columnStateHelper.js
+++ b/internal/columnStateHelper.js
@@ -146,10 +146,16 @@ function resizeColumn(state, resizeData) {
       clientY = resizeData.clientY,
       leftOffset = resizeData.leftOffset;
 
+
+  var leftCoord = leftOffset + combinedWidth - cellWidth;
+  /*if (document.dir !== "rtl") {
+    leftCoord += combinedWidth;
+  }*/
+
   return _extends({}, state, {
     isColumnResizing: true,
     columnResizingData: {
-      left: leftOffset + combinedWidth - cellWidth,
+      left: leftCoord,
       width: cellWidth,
       minWidth: cellMinWidth,
       maxWidth: cellMaxWidth,

--- a/internal/columnStateHelper.js
+++ b/internal/columnStateHelper.js
@@ -148,9 +148,6 @@ function resizeColumn(state, resizeData) {
 
 
   var leftCoord = leftOffset + combinedWidth - cellWidth;
-  /*if (document.dir !== "rtl") {
-    leftCoord += combinedWidth;
-  }*/
 
   return _extends({}, state, {
     isColumnResizing: true,

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -131,16 +131,23 @@ var FixedDataTableCell = createReactClass({
     };
 
     if (props.isColumnReordering) {
-      var originalLeft = props.columnReorderingData.originalLeft;
-      var reorderCellLeft = originalLeft + props.columnReorderingData.dragDistance;
-      var farthestPossiblePoint = props.columnGroupWidth - props.columnReorderingData.columnWidth;
+      var originalLeft, reorderCellLeft, farthestPossiblePoint;
+      if (document.dir !== "rtl") {
+        originalLeft = props.columnReorderingData.originalLeft;
+        reorderCellLeft = originalLeft + props.columnReorderingData.dragDistance;
+        farthestPossiblePoint = props.columnGroupWidth - props.columnReorderingData.columnWidth;
+      } else {
+        originalLeft = props.columnReorderingData.originalLeft;
+        reorderCellLeft = originalLeft - props.columnReorderingData.dragDistance;
+        farthestPossiblePoint = props.columnGroupWidth - props.columnReorderingData.columnWidth;
+      }
 
       // ensure the cell isn't being dragged out of the column group
       reorderCellLeft = Math.max(reorderCellLeft, 0);
       reorderCellLeft = Math.min(reorderCellLeft, farthestPossiblePoint);
 
       if (props.columnKey === props.columnReorderingData.columnKey) {
-        newState.displacement = reorderCellLeft - props.left;
+        newState.displacement = originalLeft + props.columnReorderingData.dragDistance - props.left;
         newState.isReorderingThisColumn = true;
 
       } else {

--- a/src/FixedDataTableCell.js
+++ b/src/FixedDataTableCell.js
@@ -303,7 +303,7 @@ var FixedDataTableCell = createReactClass({
 
   _onColumnResizerMouseDown(/*object*/ event) {
     this.props.onColumnResize(
-      this.props.left,
+      (document.dir !== "rtl") ? this.props.left : this.props.columnGroupWidth - this.props.left,
       this.props.width,
       this.props.minWidth,
       this.props.maxWidth,

--- a/src/FixedDataTableCellGroup.js
+++ b/src/FixedDataTableCellGroup.js
@@ -239,7 +239,7 @@ var FixedDataTableCellGroup = createReactClass({
   ) {
     this.props.onColumnResize && this.props.onColumnResize(
       this.props.offsetLeft,
-      left - this.props.left + width,
+      (document.dir !== "rtl") ? left - this.props.left + width : left - this.props.left,
       width,
       minWidth,
       maxWidth,

--- a/src/css/layout/fixedDataTableCellLayout.css
+++ b/src/css/layout/fixedDataTableCellLayout.css
@@ -16,7 +16,8 @@
   box-sizing: border-box;
   display: block;
   overflow: hidden;
-  position: absolute;
+  position: relative;
+  left: 0 !important;
   white-space: normal;
 }
 

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -131,9 +131,6 @@ function resizeColumn(state, resizeData) {
   } = resizeData;
 
   let leftCoord = leftOffset + combinedWidth - cellWidth;
-  /*if (document.dir !== "rtl") {
-    leftCoord += combinedWidth;
-  }*/
 
   return Object.assign({}, state, {
     isColumnResizing: true,

--- a/src/reducers/columnStateHelper.js
+++ b/src/reducers/columnStateHelper.js
@@ -129,10 +129,16 @@ function resizeColumn(state, resizeData) {
     clientY,
     leftOffset
   } = resizeData;
+
+  let leftCoord = leftOffset + combinedWidth - cellWidth;
+  /*if (document.dir !== "rtl") {
+    leftCoord += combinedWidth;
+  }*/
+
   return Object.assign({}, state, {
     isColumnResizing: true,
     columnResizingData: {
-      left: leftOffset + combinedWidth - cellWidth,
+      left: leftCoord,
       width: cellWidth,
       minWidth: cellMinWidth,
       maxWidth: cellMaxWidth,


### PR DESCRIPTION
Added RTL support for grid

## Description
- Changed `position `for cells from `absolute `to `relative` (for reversing columns order in RTL by browser)
- Fixed column resizing (vertical splitter position) and column reordering in RTL
- Updated internal/*.js scripts